### PR TITLE
Fix compile issue on later ESPHome (fixes #2)

### DIFF
--- a/hanover_flipdot/display.py
+++ b/hanover_flipdot/display.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_PAGES,
     CONF_ADDRESS,
 )
+from esphome.const import __version__ as ESPHOME_VERSION
 
 CODEOWNERS = ["gattrill"]
 DEPENDENCIES = ["uart"]
@@ -47,7 +48,8 @@ async def to_code(config):
     cg.add(var.set_address(config[CONF_ADDRESS]))
     cg.add(var.set_offset(config[CONF_OFFSET]))
 
-    await cg.register_component(var, config)
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
     await display.register_display(var, config)
 
     if CONF_OFFSET in config:

--- a/hanover_flipdot/hanover_flipdot.h
+++ b/hanover_flipdot/hanover_flipdot.h
@@ -27,6 +27,10 @@ class hanover_flipdot : public PollingComponent, public display::DisplayBuffer, 
   void setup() override {
     this->initialize();
   }
+ 
+  display::DisplayType get_display_type() override {
+   return display::DisplayType::DISPLAY_TYPE_BINARY;
+  }
 
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;

--- a/hanover_flipdot/hanover_flipdot.h
+++ b/hanover_flipdot/hanover_flipdot.h
@@ -1,13 +1,18 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/version.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/display/display_buffer.h"
 
 namespace esphome {
 namespace hanover_flipdot {
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 12, 0)
+class hanover_flipdot : public display::DisplayBuffer, public uart::UARTDevice  {
+#else
 class hanover_flipdot : public PollingComponent, public display::DisplayBuffer, public uart::UARTDevice  {
+#endif  // VERSION_CODE(2023, 12, 0)
  public:
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }


### PR DESCRIPTION
Implement the "get_display_type()" method, which is required by later ESPHome releases.